### PR TITLE
Implement simple PHP finance API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/api/data/*.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-TEST
+# Personal Finance API
+
+Simple PHP API to manage personal finances with basic functionality.
+
+## Features
+
+- Login route (`POST /login`)
+- Add expenses (`POST /expenses`)
+- Add incomes (`POST /incomes`)
+- Bank account registration (`POST /bankaccounts` and `GET /bankaccounts`)
+- Category registration (`POST /categories` and `GET /categories`)
+- Separate values to investments or savings using `target` field
+- Euro values handled via `amount_eur` field
+
+## Usage
+
+1. Deploy on a PHP-enabled server.
+2. Send JSON requests to the routes above.
+3. Data is stored in JSON files inside `api/data` directory.
+
+This is a minimal example and does not include advanced security or persistence features.
+
+### Example Request
+
+```bash
+# Login
+curl -X POST -H "Content-Type: application/json" -d '{"username":"admin","password":"secret"}' http://localhost/login
+```

--- a/api/controllers/AccountController.php
+++ b/api/controllers/AccountController.php
@@ -1,0 +1,28 @@
+<?php
+class AccountController {
+    private $file = __DIR__ . '/../data/accounts.json';
+
+    private function read() {
+        if (!file_exists($this->file)) return [];
+        return json_decode(file_get_contents($this->file), true) ?: [];
+    }
+
+    private function write($data) {
+        file_put_contents($this->file, json_encode($data, JSON_PRETTY_PRINT));
+    }
+
+    public function addAccount() {
+        $input = json_decode(file_get_contents('php://input'), true);
+        $accounts = $this->read();
+        $accounts[] = [
+            'id' => uniqid(),
+            'name' => $input['name'] ?? 'Unnamed',
+        ];
+        $this->write($accounts);
+        echo json_encode(['status' => 'ok']);
+    }
+
+    public function listAccounts() {
+        echo json_encode($this->read());
+    }
+}

--- a/api/controllers/AuthController.php
+++ b/api/controllers/AuthController.php
@@ -1,0 +1,32 @@
+<?php
+class AuthController {
+    private $userFile = __DIR__ . '/../data/users.json';
+
+    private function readUsers() {
+        if (!file_exists($this->userFile)) return [];
+        $data = json_decode(file_get_contents($this->userFile), true);
+        return $data ?: [];
+    }
+
+    private function writeUsers($users) {
+        file_put_contents($this->userFile, json_encode($users, JSON_PRETTY_PRINT));
+    }
+
+    public function login() {
+        $input = json_decode(file_get_contents('php://input'), true);
+        $username = $input['username'] ?? '';
+        $password = $input['password'] ?? '';
+        $users = $this->readUsers();
+        foreach ($users as $user) {
+            if ($user['username'] === $username && $user['password'] === $password) {
+                $token = bin2hex(random_bytes(16));
+                $user['token'] = $token;
+                $this->writeUsers([$user]);
+                echo json_encode(['token' => $token]);
+                return;
+            }
+        }
+        http_response_code(401);
+        echo json_encode(['error' => 'Invalid credentials']);
+    }
+}

--- a/api/controllers/CategoryController.php
+++ b/api/controllers/CategoryController.php
@@ -1,0 +1,28 @@
+<?php
+class CategoryController {
+    private $file = __DIR__ . '/../data/categories.json';
+
+    private function read() {
+        if (!file_exists($this->file)) return [];
+        return json_decode(file_get_contents($this->file), true) ?: [];
+    }
+
+    private function write($data) {
+        file_put_contents($this->file, json_encode($data, JSON_PRETTY_PRINT));
+    }
+
+    public function addCategory() {
+        $input = json_decode(file_get_contents('php://input'), true);
+        $categories = $this->read();
+        $categories[] = [
+            'id' => uniqid(),
+            'name' => $input['name'] ?? 'General',
+        ];
+        $this->write($categories);
+        echo json_encode(['status' => 'ok']);
+    }
+
+    public function listCategories() {
+        echo json_encode($this->read());
+    }
+}

--- a/api/controllers/Router.php
+++ b/api/controllers/Router.php
@@ -1,0 +1,31 @@
+<?php
+class Router {
+    private $routes = [];
+
+    public function __construct() {
+        $this->routes = [
+            'POST /login' => ['AuthController', 'login'],
+            'POST /expenses' => ['TransactionController', 'addExpense'],
+            'POST /incomes' => ['TransactionController', 'addIncome'],
+            'POST /bankaccounts' => ['AccountController', 'addAccount'],
+            'GET /bankaccounts' => ['AccountController', 'listAccounts'],
+            'POST /categories' => ['CategoryController', 'addCategory'],
+            'GET /categories' => ['CategoryController', 'listCategories'],
+            'GET /summary' => ['TransactionController', 'summary'],
+        ];
+    }
+
+    public function route($method, $uri) {
+        $path = parse_url($uri, PHP_URL_PATH);
+        $key = "$method $path";
+        if (isset($this->routes[$key])) {
+            list($class, $func) = $this->routes[$key];
+            require_once __DIR__ . "/{$class}.php";
+            $controller = new $class();
+            $controller->$func();
+        } else {
+            http_response_code(404);
+            echo json_encode(['error' => 'Route not found']);
+        }
+    }
+}

--- a/api/controllers/TransactionController.php
+++ b/api/controllers/TransactionController.php
@@ -1,0 +1,51 @@
+<?php
+class TransactionController {
+    private $file = __DIR__ . '/../data/transactions.json';
+
+    private function read() {
+        if (!file_exists($this->file)) return [];
+        return json_decode(file_get_contents($this->file), true) ?: [];
+    }
+
+    private function write($data) {
+        file_put_contents($this->file, json_encode($data, JSON_PRETTY_PRINT));
+    }
+
+    private function add($type) {
+        $input = json_decode(file_get_contents('php://input'), true);
+        $transactions = $this->read();
+        $transactions[] = [
+            'id' => uniqid(),
+            'type' => $type, // expense or income
+            'category' => $input['category'] ?? null,
+            'account' => $input['account'] ?? null,
+            'amount_eur' => (float)($input['amount_eur'] ?? 0),
+            'target' => $input['target'] ?? 'none', // savings or investments
+        ];
+        $this->write($transactions);
+        echo json_encode(['status' => 'ok']);
+    }
+
+    public function addExpense() {
+        $this->add('expense');
+    }
+
+    public function addIncome() {
+        $this->add('income');
+    }
+
+    public function summary() {
+        $transactions = $this->read();
+        $summary = ['income' => 0, 'expense' => 0, 'savings' => 0, 'investments' => 0];
+        foreach ($transactions as $t) {
+            if ($t['type'] === 'income') {
+                $summary['income'] += $t['amount_eur'];
+                if ($t['target'] === 'savings') $summary['savings'] += $t['amount_eur'];
+                if ($t['target'] === 'investments') $summary['investments'] += $t['amount_eur'];
+            } else {
+                $summary['expense'] += $t['amount_eur'];
+            }
+        }
+        echo json_encode($summary);
+    }
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,5 @@
+<?php
+require_once __DIR__ . '/api/controllers/Router.php';
+
+$router = new Router();
+$router->route($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI']);


### PR DESCRIPTION
## Summary
- set up a simple router and controllers
- add routes for login, expenses, incomes, bank accounts, categories, and summary
- store data in JSON files
- document basic usage in README

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b38837b20832799b0f121e64be88c